### PR TITLE
tag がねーよってエラーでてレポート作成に失敗しちょる

### DIFF
--- a/lib/turnip_formatter/printer/tab_tag_statistics.rb
+++ b/lib/turnip_formatter/printer/tab_tag_statistics.rb
@@ -53,12 +53,17 @@ module TurnipFormatter
         #
         def group_by_tag(scenarios)
           scenarios.map do |scenario|
-            if scenario.tags.empty?
-              { name: 'turnip', scenario: scenario }
-            else
-              scenario.tags.map do |tag|
-                { name: '@' + tag, scenario: scenario }
+            begin
+              scenario.validation
+              if scenario.tags.empty?
+                { name: 'turnip', scenario: scenario }
+              else
+                scenario.tags.map do |tag|
+                  { name: '@' + tag, scenario: scenario }
+                end
               end
+            rescue
+              { name: 'runtime error', scenario: scenario }
             end
           end.flatten.group_by { |s| s[:name] }.sort
         end

--- a/spec/turnip_formatter/printer/tab_tag_statistics_spec.rb
+++ b/spec/turnip_formatter/printer/tab_tag_statistics_spec.rb
@@ -23,24 +23,28 @@ module TurnipFormatter::Printer
       # Failed scenario have tags @hoge and @fuga
       scenario = base_scenario.dup
       scenario.stub(:tags).and_return(['foo', 'bar'])
+      scenario.stub(:validation).and_return(true)
       scenario.stub(:status).and_return('failed')
       scenarios << scenario
 
       # Passed scenario no have tags
       scenario = base_scenario.dup
       scenario.stub(:tags).and_return([])
+      scenario.stub(:validation).and_return(true)
       scenario.stub(:status).and_return('passed')
       scenarios << scenario
 
       # Passed scenario have tags @hoge
       scenario = base_scenario.dup
       scenario.stub(:tags).and_return(['hoge'])
+      scenario.stub(:validation).and_return(true)
       scenario.stub(:status).and_return('passed')
       scenarios << scenario
 
       # Pending scenario have tags @fuga and @hago
       scenario = base_scenario.dup
       scenario.stub(:tags).and_return(['bar', 'hoge'])
+      scenario.stub(:validation).and_return(true)
       scenario.stub(:status).and_return('pending')
       scenarios << scenario
     end


### PR DESCRIPTION
```
/home/gongo/test/vendor/bundle/ruby/1.9.1/gems/turnip_formatter-0.2.4/lib/turnip_formatter/scenario.rb:70:in `tags': undefined method `[]' for nil:NilClass (NoMethodError)
    from /home/gongo/test/vendor/bundle/ruby/1.9.1/gems/turnip_formatter-0.2.4/lib/turnip_formatter/printer/tab_tag_statistics.rb:60:in `block in group_by_tag'
    from /home/gongo/test/vendor/bundle/ruby/1.9.1/gems/turnip_formatter-0.2.4/lib/turnip_formatter/printer/tab_tag_statistics.rb:59:in `map'
    from /home/gongo/test/vendor/bundle/ruby/1.9.1/gems/turnip_formatter-0.2.4/lib/turnip_formatter/printer/tab_tag_statistics.rb:59:in `group_by_tag'
    from /home/gongo/test/vendor/bundle/ruby/1.9.1/gems/turnip_formatter-0.2.4/lib/turnip_formatter/printer/tab_tag_statistics.rb:13:in `print_out'
    from (erb):52:in `template_params_binding'
    from /home/admin/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/erb.rb:838:in `eval'
    from /home/admin/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/erb.rb:838:in `result'
    from /home/gongo/test/vendor/bundle/ruby/1.9.1/gems/turnip_formatter-0.2.4/lib/turnip_formatter/printer.rb:11:in `render_template'
    from /home/gongo/test/vendor/bundle/ruby/1.9.1/gems/turnip_formatter-0.2.4/lib/turnip_formatter/printer/index.rb:17:in `print_out'
    from /home/gongo/test/vendor/bundle/ruby/1.9.1/gems/turnip_formatter-0.2.4/lib/rspec/core/formatters/turnip_formatter.rb:26:in `dump_summary'
```

このタグっていうのは [lib/turnip_formatter/ext/turnip/rspec.rb](https://github.com/gongo/turnip_formatter/blob/v0.2.4/lib/turnip_formatter/ext/turnip/rspec.rb#L50) で定義されており、tags が nil になるタイミングが今いちわかってない。

が、まあとりあえずエラー出て数十分のテスト結果が一個も出なくなるのは悲しいので、とりあえず nil だったら `[]` 返すぐらいの気持ちでいこうと思う
