### PR TITLE
js や css の minify をやめる

### DIFF
--- a/lib/turnip_formatter/template.rb
+++ b/lib/turnip_formatter/template.rb
@@ -2,7 +2,6 @@
 
 require 'turnip_formatter/template'
 require 'sass'
-require 'uglifier'
 
 module TurnipFormatter
   class Template
@@ -12,7 +11,7 @@ module TurnipFormatter
       end
 
       def add_js_file(file)
-        js_list << Uglifier.compile(File.read(file))
+        js_list << File.read(file)
       end
 
       def add_scss(scss_string)

--- a/turnip_formatter.gemspec
+++ b/turnip_formatter.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'turnip'
   spec.add_dependency 'sass'
-  spec.add_dependency 'uglifier'
-  spec.add_dependency 'therubyracer'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec-html-matchers'


### PR DESCRIPTION
#24 で導入したんだけど、あまりいらない気がしたのでやめます。

(js の minify してもそれ以上に画像がかさばるので 依存パッケージ増やしてまでやるメリットがなくなった)
