### PR TITLE
Remove Tilt from dependent packages

### DIFF
--- a/lib/turnip_formatter/printer.rb
+++ b/lib/turnip_formatter/printer.rb
@@ -1,4 +1,4 @@
-require 'tilt'
+require 'haml'
 
 module TurnipFormatter
   module Printer
@@ -11,12 +11,12 @@ module TurnipFormatter
       render_template_list(name).render(self, params)
     end
 
-    private
+  private
 
     def render_template_list(name)
       if templates[name].nil?
         path = File.dirname(__FILE__) + "/template/#{name}.haml"
-        templates[name] = Tilt.new(path)
+        templates[name] = Haml::Engine.new(File.read(path))
       end
 
       templates[name]

--- a/turnip_formatter.gemspec
+++ b/turnip_formatter.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'turnip', '~> 1.2.2'
-  spec.add_dependency 'tilt'
   spec.add_dependency 'haml'
   spec.add_dependency 'sass'
   spec.add_dependency 'bootstrap-sass'


### PR DESCRIPTION
Tilt became unnecessary because only using Haml.
