### PR TITLE
Step report should be html escaped.

### DIFF
--- a/lib/turnip_formatter/renderer/html/views/step.html.erb
+++ b/lib/turnip_formatter/renderer/html/views/step.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= id %>" class="step <%= status %>">
-  <div class="step-title"><%= keyword %> <%= text %></div>
+  <div class="step-title"><%= ERB::Util.h(keyword) %> <%= ERB::Util.h(text) %></div>
 
   <% if has_appendix? %>
   <div class="step-body">

--- a/test/turnip_formatter/renderer/html/test_step.rb
+++ b/test/turnip_formatter/renderer/html/test_step.rb
@@ -35,6 +35,21 @@ module TurnipFormatter::Renderer::Html
       end
     end
 
+    sub_test_case 'step should be escaped html style' do
+      def setup
+        resource = TurnipFormatter::Resource::Step.new(nil, sample_step_should_escaping)
+        @renderer = Step.new(resource)
+      end
+
+      def test_render
+        rendered = @renderer.render
+        document = html_parse(@renderer.render).at_xpath('/div')
+
+        assert_not_nil(%r{<div class="step-title">When step &gt;should&lt; escaped</div>}.match(rendered))
+        assert_nil(document.at_css('div.step-body'))
+      end
+    end
+
     private
 
     def sample_step
@@ -43,6 +58,10 @@ module TurnipFormatter::Renderer::Html
 
     def sample_step_with_docstring
       sample_feature.scenarios[0].steps[1]
+    end
+
+    def sample_step_should_escaping
+      sample_feature.scenarios[0].steps[2]
     end
 
     def sample_feature
@@ -59,6 +78,7 @@ module TurnipFormatter::Renderer::Html
               """
               DocString
               """
+            When step >should< escaped
       EOS
     end
   end


### PR DESCRIPTION
I found non escaped step title broken my report.
I use turnip_formatter 0.6.0.pre.beta.3.

With steps like berow
```
Scenario: sample
   Step click < icon on view.
```

expected `<div class="step-title">Step click &lt; mark on view.</div>`,
but got `<div class="step-title">Step click < mark on view.</div>`.

so, i fix it.