### PR TITLE
Support errors occur at before and after hook.

### DIFF
--- a/example/spec/features/rspec_hooks.feature
+++ b/example/spec/features/rspec_hooks.feature
@@ -13,3 +13,10 @@ Feature: Battle a monster with hooks
      When I attack it
      Then it should die
       And Fanfare
+
+  @after_hook_error
+  Scenario: [ERROR] Error in steps and after hook
+    Given there is a strong monster
+     When I attack it
+     Then it should die
+      And Fanfare

--- a/example/spec/features/rspec_hooks.feature
+++ b/example/spec/features/rspec_hooks.feature
@@ -1,0 +1,15 @@
+Feature: Battle a monster with hooks
+
+  @before_hook_error
+  Scenario: [ERROR] Error in before hook
+    Given there is a monster
+     When I attack it
+     Then it should die
+      And Fanfare
+
+  @after_hook_error
+  Scenario: [ERROR] Error in after hook
+    Given there is a monster
+     When I attack it
+     Then it should die
+      And Fanfare

--- a/example/spec/spec_helper.rb
+++ b/example/spec/spec_helper.rb
@@ -6,6 +6,16 @@ end
 
 Dir.glob(File.dirname(__FILE__) + '/steps/**/*steps.rb') { |f| load f, true }
 
+RSpec.configure do |config|
+  config.before(:example, before_hook_error: true) do
+    undefined_method # NameError
+  end
+
+  config.after(:example, after_hook_error: true) do
+    expect(true).to be false # RSpec Matcher Error
+  end
+end
+
 # TurnipFormatter.configure do |config|
 #   config.title = 'My Report'
 #   config.add_stylesheet File.dirname(__FILE__) + '/foo.css'

--- a/lib/rspec/core/formatters/turnip_formatter.rb
+++ b/lib/rspec/core/formatters/turnip_formatter.rb
@@ -15,9 +15,10 @@ module RSpec
 
         Formatters.register self, :example_passed, :example_pending, :example_failed, :dump_summary
 
-        def self.formatted_backtrace(example)
+        def self.formatted_backtrace(example, exception = nil)
+          exception = example.exception if exception.nil?
           formatter = RSpec.configuration.backtrace_formatter
-          formatter.format_backtrace(example.exception.backtrace, example.metadata)
+          formatter.format_backtrace(exception.backtrace, example.metadata)
         end
 
         def initialize(output)

--- a/lib/turnip_formatter/resource/hook.rb
+++ b/lib/turnip_formatter/resource/hook.rb
@@ -1,0 +1,30 @@
+module TurnipFormatter
+  module Resource
+    class Hook
+      attr_reader :example
+      attr_reader :keyword
+      attr_reader :status
+
+      #
+      # @param  [RSpec::Core::Example]  example
+      #
+      def initialize(example, keyword, status)
+        @example = example
+        @keyword = keyword
+        @status = status
+      end
+
+      def text
+        ''
+      end
+
+      def line
+        -1
+      end
+
+      def argument
+        nil
+      end
+    end
+  end
+end

--- a/lib/turnip_formatter/resource/scenario/failure.rb
+++ b/lib/turnip_formatter/resource/scenario/failure.rb
@@ -5,6 +5,8 @@ module TurnipFormatter
   module Resource
     module Scenario
       class Failure < Base
+        alias :super_steps :steps
+
         #
         # Return steps
         #
@@ -34,7 +36,7 @@ module TurnipFormatter
         private
 
         def steps_with_error
-          steps = method(:steps).super_method.call
+          steps = super_steps
 
           arys = steps.group_by { |s| (s.line <=> failed_line_number).to_s }
           arys['-1'].each { |s| s.status = :passed    } unless arys['-1'].nil?
@@ -45,15 +47,14 @@ module TurnipFormatter
         end
 
         def steps_with_error_in_before_hook
-          steps = method(:steps).super_method.call
+          steps = super_steps
 
           steps.each { |s| s.status = :unexecute }
           [TurnipFormatter::Resource::Hook.new(example, 'BeforeHook', :failed)] + steps
         end
 
         def steps_with_error_in_after_hook
-          steps = method(:steps).super_method.call
-          steps + [TurnipFormatter::Resource::Hook.new(example, 'AfterHook', :failed)]
+          super_steps + [TurnipFormatter::Resource::Hook.new(example, 'AfterHook', :failed)]
         end
 
         def error_in_steps?

--- a/lib/turnip_formatter/resource/scenario/failure.rb
+++ b/lib/turnip_formatter/resource/scenario/failure.rb
@@ -1,4 +1,5 @@
 require 'turnip_formatter/resource/scenario/base'
+require 'turnip_formatter/resource/hook'
 
 module TurnipFormatter
   module Resource
@@ -19,11 +20,21 @@ module TurnipFormatter
         #   #<Step 'baz'>.status = :failed
         #   #<Step 'piyo'>.status = :unexecute
         #
-        #
-        # @todo failed_at_before_hook, failed_at_after_hook GH-67
-        #
         def steps
-          steps = super
+          case
+          when error_in_steps?
+            steps_with_error
+          when error_in_before_hook?
+            steps_with_error_in_before_hook
+          when error_in_after_hook?
+            steps_with_error_in_after_hook
+          end
+        end
+
+        private
+
+        def steps_with_error
+          steps = method(:steps).super_method.call
 
           arys = steps.group_by { |s| (s.line <=> failed_line_number).to_s }
           arys['-1'].each { |s| s.status = :passed    } unless arys['-1'].nil?
@@ -33,7 +44,33 @@ module TurnipFormatter
           steps
         end
 
-        private
+        def steps_with_error_in_before_hook
+          steps = method(:steps).super_method.call
+
+          steps.each { |s| s.status = :unexecute }
+          [TurnipFormatter::Resource::Hook.new(example, 'BeforeHook', :failed)] + steps
+        end
+
+        def steps_with_error_in_after_hook
+          steps = method(:steps).super_method.call
+          steps + [TurnipFormatter::Resource::Hook.new(example, 'AfterHook', :failed)]
+        end
+
+        def error_in_steps?
+          !failed_line_number.nil?
+        end
+
+        def error_in_before_hook?
+          example.exception.backtrace.any? do |backtrace|
+            backtrace.match(/run_before_example/)
+          end
+        end
+
+        def error_in_after_hook?
+          example.exception.backtrace.any? do |backtrace|
+            backtrace.match(/run_after_example/)
+          end
+        end
 
         def failed_line_number
           @failed_line_number ||= (

--- a/lib/turnip_formatter/step_template/base.rb
+++ b/lib/turnip_formatter/step_template/base.rb
@@ -30,8 +30,8 @@ module TurnipFormatter
         end
       end
 
-      def formatted_backtrace(example)
-        RSpec::Core::Formatters::TurnipFormatter.formatted_backtrace(example)
+      def formatted_backtrace(example, exception = nil)
+        RSpec::Core::Formatters::TurnipFormatter.formatted_backtrace(example, exception)
       end
     end
   end

--- a/lib/turnip_formatter/step_template/exception.rb
+++ b/lib/turnip_formatter/step_template/exception.rb
@@ -28,7 +28,13 @@ module TurnipFormatter
       # @param  [RSpec::Core::Example]  example
       #
       def build_failed(example)
-        build(example.exception.to_s, formatted_backtrace(example))
+        exception = example.exception
+
+        if example.exception.is_a?(RSpec::Core::MultipleExceptionError)
+          exception = example.exception.all_exceptions.first
+        end
+
+        build(exception.to_s, formatted_backtrace(example, exception))
       end
 
       #
@@ -40,13 +46,13 @@ module TurnipFormatter
 
       private
 
-        def build(message, backtrace)
-          template_step_exception.render(Object.new, { message: message, backtrace: backtrace })
-        end
+      def build(message, backtrace)
+        template_step_exception.render(Object.new, { message: message, backtrace: backtrace })
+      end
 
-        def template_step_exception
-          @template_step_exception ||= Slim::Template.new(File.dirname(__FILE__) + "/exception.slim")
-        end
+      def template_step_exception
+        @template_step_exception ||= Slim::Template.new(File.dirname(__FILE__) + "/exception.slim")
+      end
     end
   end
 end

--- a/lib/turnip_formatter/step_template/source.rb
+++ b/lib/turnip_formatter/step_template/source.rb
@@ -38,7 +38,13 @@ module TurnipFormatter
       private
 
       def location(example)
-        formatted_backtrace(example).first
+        exception = example.exception
+
+        if example.exception.is_a?(RSpec::Core::MultipleExceptionError)
+          exception = example.exception.all_exceptions.first
+        end
+
+        formatted_backtrace(example, exception).first
       end
 
       def extractor

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -71,6 +71,14 @@ module TurnipFormatter
       rspec_context.include(Turnip::RSpec::Execute)
       rspec_context.include(ExecuteWrapper)
 
+      rspec_context.before(:example, before_hook_error: true) do
+        undefined_method # NameError
+      end
+
+      rspec_context.after(:example, after_hook_error: true) do
+        expect(true).to be false # RSpec Matcher Error
+      end
+
       Turnip::RSpec.__send__(:run_feature, rspec_context, feature, filename)
       rspec_context.run(NoopObject.new)
       Turnip::RSpec.update_metadata(feature, rspec_context)

--- a/test/turnip_formatter/resource/scenario/test_failure.rb
+++ b/test/turnip_formatter/resource/scenario/test_failure.rb
@@ -5,35 +5,79 @@ module TurnipFormatter::Resource::Scenario
   class TestFailure < Test::Unit::TestCase
     include TurnipFormatter::TestHelper
 
-    def setup
-      @resource = Failure.new(scenario_example)
-    end
-
     def test_status
+      @resource = Failure.new(scenario_example)
       assert_equal(:failed, @resource.status)
     end
 
     def test_steps
+      @resource = Failure.new(scenario_example)
+
       expect = [:passed, :failed, :unexecute]
       actual = @resource.steps.map(&:status)
 
       assert_equal(expect, actual)
     end
 
+    def test_steps_has_error_in_before_hook
+      @resource = Failure.new(scenario_error_before_hook)
+
+      expect = [:failed, :unexecute, :unexecute]
+      actual = @resource.steps.map(&:status)
+
+      assert_equal(expect, actual)
+      assert_equal(TurnipFormatter::Resource::Hook, @resource.steps.first.class)
+    end
+
+    def test_steps_has_error_in_after_hook
+      @resource = Failure.new(scenario_error_after_hook)
+
+      expect = [:passed, :passed, :failed]
+      actual = @resource.steps.map(&:status)
+
+      assert_equal(expect, actual)
+      assert_equal(TurnipFormatter::Resource::Hook, @resource.steps.last.class)
+    end
+
     private
 
     def scenario_example
-      @@scenario_example ||= (
-        feature = feature_build(<<-EOS)
-          Feature: A simple feature
-            Scenario: This is a simple feature
-              When I attack it
-              Then [ERROR] it should die
-               And I get drop items
-        EOS
+      scenario_examples[0]
+    end
 
-        run_feature(feature, '/path/to/test.feature').first
+    def scenario_error_before_hook
+      scenario_examples[1]
+    end
+
+    def scenario_error_after_hook
+      scenario_examples[2]
+    end
+
+    def scenario_examples
+      @@scenario_examples ||= (
+        feature = feature_build(feature_text)
+        run_feature(feature, '/path/to/test.feature')
       )
+    end
+
+    def feature_text
+      <<-EOS
+        Feature: A simple feature
+          Scenario: This is a simple feature
+            When I attack it
+            Then [ERROR] it should die
+             And I get drop items
+
+          @before_hook_error
+          Scenario: Error in before hook
+            When I attack it
+            Then it should die
+
+          @after_hook_error
+          Scenario: Error in after hook
+            When I attack it
+            Then it should die
+      EOS
     end
   end
 end

--- a/test/turnip_formatter/resource/scenario/test_failure.rb
+++ b/test/turnip_formatter/resource/scenario/test_failure.rb
@@ -39,6 +39,16 @@ module TurnipFormatter::Resource::Scenario
       assert_equal(TurnipFormatter::Resource::Hook, @resource.steps.last.class)
     end
 
+    def test_steps_has_error_in_steps_and_after_hook
+      @resource = Failure.new(scenario_error_step_and_after_hook)
+
+      expect = [:passed, :failed, :unexecute]
+      actual = @resource.steps.map(&:status)
+
+      assert_equal(expect, actual)
+      assert_equal(TurnipFormatter::Resource::Step, @resource.steps.last.class)
+    end
+
     private
 
     def scenario_example
@@ -51,6 +61,10 @@ module TurnipFormatter::Resource::Scenario
 
     def scenario_error_after_hook
       scenario_examples[2]
+    end
+
+    def scenario_error_step_and_after_hook
+      scenario_examples[3]
     end
 
     def scenario_examples
@@ -77,6 +91,13 @@ module TurnipFormatter::Resource::Scenario
           Scenario: Error in after hook
             When I attack it
             Then it should die
+
+          @after_hook_error
+          Scenario: Error in after hook
+            When I attack it
+            Then [ERROR] it should die
+             And I get drop items
+
       EOS
     end
   end


### PR DESCRIPTION
## Motivation

When errors occur at RSpec before/after hook block:

- Before 0.5.0
    - Errors occur GH-67
- 0.6.x beta4
    - No error occur but no display

        ![2017-01-06 22 10 30](https://cloud.githubusercontent.com/assets/124713/21718781/003c04d2-d45d-11e6-8d34-9ac58a52361a.png)

## Solution

🍕 

At before hook:

![2017-01-06 22 04 36](https://cloud.githubusercontent.com/assets/124713/21718791/1540da10-d45d-11e6-8563-d969df3052cc.png)

At after hook:

![2017-01-06 22 04 44](https://cloud.githubusercontent.com/assets/124713/21718797/2459b9e0-d45d-11e6-8a5d-1f9b7e541eb7.png)
