### PR TITLE
Remove tests for RSpec 3.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
 
 matrix:
   allow_failures:
-    - gemfile: gemfiles/Gemfile-rspec-3.2.x
     - rvm: ruby-head
 
 rvm:
@@ -24,6 +23,5 @@ script:
   - bundle exec rake test
 
 gemfile:
-  - gemfiles/Gemfile-rspec-3.2.x
   - gemfiles/Gemfile-rspec-3.3.x
   - gemfiles/Gemfile-rspec-3.4.x

--- a/gemfiles/Gemfile-rspec-3.2.x
+++ b/gemfiles/Gemfile-rspec-3.2.x
@@ -1,4 +1,0 @@
-source 'http://rubygems.org'
-
-gemspec :path => '..'
-gem 'rspec', '~> 3.2.0'

--- a/turnip_formatter.gemspec
+++ b/turnip_formatter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'turnip', '~> 3.0.0.pre.beta.4'
   spec.add_dependency 'slim'
-  spec.add_dependency 'rspec', [">=3.0", "<3.5"]
+  spec.add_dependency 'rspec', [">=3.3", "<3.5"]
 
   # For ruby >= 2.1
   spec.add_dependency 'activesupport', '~> 4.2.7'


### PR DESCRIPTION
In GH-83, don't working on RSpec 3.2 (MultipleExceptionError..)