### PR TITLE
RuntimeError is TurnipFormatter::Renderer::Html::RuntimeError

### DIFF
--- a/lib/turnip_formatter/renderer/html/index.rb
+++ b/lib/turnip_formatter/renderer/html/index.rb
@@ -1,5 +1,6 @@
 require 'turnip_formatter'
 require 'turnip_formatter/renderer/html/scenario'
+require 'turnip_formatter/renderer/html/runtime_error'
 require 'turnip_formatter/renderer/html/statistics_feature'
 require 'turnip_formatter/renderer/html/statistics_tag'
 require 'turnip_formatter/renderer/html/statistics_speed'


### PR DESCRIPTION
😓 

```ruby
          scenarios.map do |s|
            begin
              Scenario.new(s).render
            rescue => e
              RuntimeError.new([e, s]).render # <= was recognized as builtin RuntimeError
            end
          end.join
```


https://github.com/gongo/turnip_formatter/issues/67#issuecomment-273672501