### PR TITLE
Slim is no longer used

### DIFF
--- a/turnip_formatter.gemspec
+++ b/turnip_formatter.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'turnip', '~> 3.0.0.pre.beta.4'
-  spec.add_dependency 'slim'
   spec.add_dependency 'rspec', [">=3.3", "<3.5"]
 
   # For ruby >= 2.1


### PR DESCRIPTION
> - Use ERB instead of Slim
>     - I can not read slim template code for the first time in a year.
>
> GH-69

😄 