### PR TITLE
Support Ruby 2.2 or later (Drop 2.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
     - rvm: ruby-head
 
 rvm:
-  - 2.1
   - 2.2
   - 2.3.0
+  - 2.4.0
   - ruby-head
   - jruby-9.0.5.0
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 --------------------
 
 * Ruby
-    * `2.1.0` or later
+    * `2.2.0` or later
 
 Installation
 --------------------


### PR DESCRIPTION
- 🎉 Ruby 2.4.1 Released
    - https://www.ruby-lang.org/en/news/2017/03/22/ruby-2-4-1-released/

- ✋ Support of Ruby 2.1 has ended
    - https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/