### PR TITLE
Support activesupport 5.x series

### DIFF
--- a/turnip_formatter.gemspec
+++ b/turnip_formatter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rspec', [">=3.3", "<4.0"]
 
   # For ruby >= 2.1
-  spec.add_dependency 'activesupport', '~> 4.2.7'
+  spec.add_dependency 'activesupport', '>= 4.2.7', '< 6.0'
 
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'test-unit-rr'


### PR DESCRIPTION
activesupport 5.0, 5.1 and 5.2 has String#{demodulize,underscore} as same as 4.2.7

* 4.2.7
  * [String#demodulize](https://github.com/rails/rails/blob/v4.2.7/activesupport/lib/active_support/core_ext/string/inflections.rb#L137)
  * [String#underscore](https://github.com/rails/rails/blob/v4.2.7/activesupport/lib/active_support/core_ext/string/inflections.rb#L118)
* 5.0.7
  * [String#demodulize](https://github.com/rails/rails/blob/v5.0.7/activesupport/lib/active_support/core_ext/string/inflections.rb#L137)
  * [String#underscore](https://github.com/rails/rails/blob/v5.0.7/activesupport/lib/active_support/core_ext/string/inflections.rb#L118)
* 5.1.6
  * [String#demodulize](https://github.com/rails/rails/blob/v5.1.6/activesupport/lib/active_support/core_ext/string/inflections.rb#L137)
  * [String#underscore](https://github.com/rails/rails/blob/v5.1.6/activesupport/lib/active_support/core_ext/string/inflections.rb#L118)
* 5.2.0
  * [String#demodulize](https://github.com/rails/rails/blob/v5.2.0/activesupport/lib/active_support/core_ext/string/inflections.rb#L146)
  * [String#underscore](https://github.com/rails/rails/blob/v5.2.0/activesupport/lib/active_support/core_ext/string/inflections.rb#L127)

so it seems no problem to update gem dependency.
