### PR TITLE
Support RSpec 3.7 and 3.8 (drop 3.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ script:
   - bundle exec rake test
 
 gemfile:
-  - gemfiles/Gemfile-rspec-3.6.x
   - gemfiles/Gemfile-rspec-3.7.x
+  - gemfiles/Gemfile-rspec-3.8.x

--- a/gemfiles/Gemfile-rspec-3.8.x
+++ b/gemfiles/Gemfile-rspec-3.8.x
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
 
 gemspec :path => '..'
-gem 'rspec', '~> 3.6.0'
+gem 'rspec', '~> 3.8.0'


### PR DESCRIPTION
http://rspec.info/blog/2018/08/rspec-3-8-has-been-released/