### PR TITLE
Drop support Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ branches:
     - master
 
 rvm:
-  - 2.2
   - 2.3.6
   - 2.4.3
-  - 2.5.0
+  - 2.5.3
   - jruby-9.0.5.0
 
 script:


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/