### PR TITLE
Support activesupport 6.x series

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ branches:
   only:
     - master
 
+matrix:
+  allow_failures:
+  - rvm: jruby-9.2.8.0
+
 rvm:
   - 2.3.6
   - 2.4.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.3
-  - jruby-9.0.5.0
+  - jruby-9.2.8.0
 
 script:
   - bundle exec rake test

--- a/turnip_formatter.gemspec
+++ b/turnip_formatter.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'test-unit-rr'
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'sass'

--- a/turnip_formatter.gemspec
+++ b/turnip_formatter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rspec', [">=3.3", "<4.0"]
 
   # For ruby >= 2.1
-  spec.add_dependency 'activesupport', '>= 4.2.7', '< 6.0'
+  spec.add_dependency 'activesupport', '>= 4.2.7', '< 7.0'
 
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'test-unit-rr'


### PR DESCRIPTION
activesupport 6.0 has String#{demodulize,underscore} as same as 4.2.7

* 4.2.7
  * [String#demodulize](https://github.com/rails/rails/blob/v4.2.7/activesupport/lib/active_support/core_ext/string/inflections.rb#L137)
  * [String#underscore](https://github.com/rails/rails/blob/v4.2.7/activesupport/lib/active_support/core_ext/string/inflections.rb#L118)

* 6.0.0
  * [String#demodulize](https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/core_ext/string/inflections.rb#L146)
  * [String#underscore](https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/core_ext/string/inflections.rb#L127)

Related PR: https://github.com/gongo/turnip_formatter/pull/99

so it seems no problem to update gem dependency.

<hr>

Since Test fell, I modified the following.

Travis CI log
```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile-rspec-3.7.x:
    bundler (~> 1.3)
  Current Bundler version:
    bundler (2.0.2)
```
