### PR TITLE
Set coveralls environment.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,4 +30,8 @@ jobs:
       - name: Run tests
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          CI_NAME: GitHub Actions
+          CI_BUILD_NUMBER: ${{ github.run_number }}
+          CI_BRANCH: ${{ github.ref }}
+          CI_PULL_REQUEST: ${{ github.event.pull_request.html_url }}
         run: bundle exec rake test


### PR DESCRIPTION
## Motivation

https://github.com/gongo/turnip_formatter/actions/runs/6083586068/job/16503755276

I want them to be recognized as the same build, but they are currently recognized as different builds.

![image](https://github.com/gongo/turnip_formatter/assets/124713/4c3995f6-8f20-4162-8219-09b42f30da63)

